### PR TITLE
Tests show correct files and line numbers when they fail now

### DIFF
--- a/client/config/test/webpack.js
+++ b/client/config/test/webpack.js
@@ -3,7 +3,7 @@
 var webpack = require('webpack');
 
 module.exports = {
-  devtool: 'source-map',
+  devtool: 'cheap-module-source-map',
   module: {
     preLoaders: [
       {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "karma-sourcemap-loader": "0.3.x",
     "karma-spec-reporter": "0.0.x",
     "karma-webpack": "1.7.x",
+    "karma-webpack-with-fast-source-maps": "^1.9.2",
     "mkdirp": "0.5.x",
     "node-sass": "3.4.x",
     "phantomjs-prebuilt": "2.1.x",
@@ -82,6 +83,9 @@
     "ejs": "2.4.x"
   },
   "author": "Eric Hulburd <eric@analyticsfire.com> (http://afdc.co/)",
-  "repository" : { "type" : "git", "url" : "https://github.com/AnalyticsFire/spike" },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AnalyticsFire/spike"
+  },
   "license": "ISC"
 }


### PR DESCRIPTION
https://trello.com/c/dBygsoVB/31-make-tests-show-correct-file-and-line-numbers-when-they-fail-using-sourcemaps

Smoke test:
1. run npm test
2. if something fails it should show exact file and line number besides test.client.js line number 
